### PR TITLE
Функция get_link возвращает байтовую строку вместо ссылки на потоковое видео для скачивания.

### DIFF
--- a/src/anime_parsers_ru/parser_kodik.py
+++ b/src/anime_parsers_ru/parser_kodik.py
@@ -603,8 +603,9 @@ class KodikParser:
 
         link_data, max_quality = self._get_link_with_data(video_type, video_hash, video_id, urlParams, script_url)
 
-        download_url = str(link_data).replace("https://", '')
-        download_url = download_url[:-26] # :hls:manifest.m3u8
+        download_url = str(link_data).replace("https://", "")
+        download_url = download_url.replace("//", "")[:-26]
+        download_url = download_url[:-26]  # :hls:manifest.m3u8
 
         return download_url, max_quality
     

--- a/src/anime_parsers_ru/parser_kodik.py
+++ b/src/anime_parsers_ru/parser_kodik.py
@@ -629,29 +629,13 @@ class KodikParser:
 
         post_link = self._get_post_link(script_url)
         data = requests.post(f'https://kodik.info{post_link}', data=params, headers=headers).json()
-        url = self._convert(data['links']['360'][0]['src'])
+        url = data['links']['360'][0]['src']
         max_quality = max([int(x) for x in data['links'].keys()])
         try:
-            return b64decode(url.encode()), max_quality
+            return url, max_quality
         except:
-            return str(b64decode(url.encode()+b'==')).replace("https:", ''), max_quality
-        
-    def _convert_char(self, char: str):
-        low = char.islower()
-        alph = "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
-        if char.upper() in alph:
-            ch = alph[(alph.index(char.upper())+13)%len(alph)]
-            if low:
-                return ch.lower()
-            else:
-                return ch
-        else:
-            return char
-
-    def _convert(self, string: str):
-        # Декодирование строки со ссылкой
-        return "".join(map(self._convert_char, list(string)))
-    
+            return url.replace("https:", ''), max_quality
+            
     def _get_post_link(self, script_url: str):
         data = requests.get('https://kodik.info'+script_url).text
         url = data[data.find("$.ajax")+30:data.find("cache:!1")-3]

--- a/src/anime_parsers_ru/parser_kodik.py
+++ b/src/anime_parsers_ru/parser_kodik.py
@@ -604,7 +604,7 @@ class KodikParser:
         link_data, max_quality = self._get_link_with_data(video_type, video_hash, video_id, urlParams, script_url)
 
         download_url = str(link_data).replace("https://", '')
-        download_url = download_url[2:-26] # :hls:manifest.m3u8
+        download_url = download_url[:-26] # :hls:manifest.m3u8
 
         return download_url, max_quality
     

--- a/src/anime_parsers_ru/parser_kodik_async.py
+++ b/src/anime_parsers_ru/parser_kodik_async.py
@@ -614,7 +614,7 @@ class KodikParserAsync:
         link_data, max_quality = await self._get_link_with_data(video_type, video_hash, video_id, urlParams, script_url)
 
         download_url = str(link_data).replace("https://", '')
-        download_url = download_url[2:-26] # :hls:manifest.m3u8
+        download_url = download_url[:-26] # :hls:manifest.m3u8
 
         return download_url, max_quality
     

--- a/src/anime_parsers_ru/parser_kodik_async.py
+++ b/src/anime_parsers_ru/parser_kodik_async.py
@@ -613,8 +613,9 @@ class KodikParserAsync:
 
         link_data, max_quality = await self._get_link_with_data(video_type, video_hash, video_id, urlParams, script_url)
 
-        download_url = str(link_data).replace("https://", '')
-        download_url = download_url[:-26] # :hls:manifest.m3u8
+        download_url = str(link_data).replace("https://", "")
+        download_url = download_url.replace("//", "")
+        download_url = download_url[:-26]  # :hls:manifest.m3u8
 
         return download_url, max_quality
     

--- a/src/anime_parsers_ru/parser_kodik_async.py
+++ b/src/anime_parsers_ru/parser_kodik_async.py
@@ -640,28 +640,13 @@ class KodikParserAsync:
         post_link = await self._get_post_link(script_url)
         data = await self.requests.post(f'https://kodik.info{post_link}', data=params, headers=headers)
         data = data.json()
-        url = self._convert(data['links']['360'][0]['src'])
+        url = data['links']['360'][0]['src']
         max_quality = max([int(x) for x in data['links'].keys()])
         try:
-            return b64decode(url.encode()), max_quality
+            return url, max_quality
         except:
-            return str(b64decode(url.encode()+b'==')).replace("https:", ''), max_quality
+            return url.replace("https:", ''), max_quality
         
-    def _convert_char(self, char: str):
-        low = char.islower()
-        alph = "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
-        if char.upper() in alph:
-            ch = alph[(alph.index(char.upper())+13)%len(alph)]
-            if low:
-                return ch.lower()
-            else:
-                return ch
-        else:
-            return char
-
-    def _convert(self, string: str):
-        # Декодирование строки со ссылкой
-        return "".join(map(self._convert_char, list(string)))
     
     async def _get_post_link(self, script_url: str):
         data = await self.requests.get('https://kodik.info'+script_url)


### PR DESCRIPTION
Вот пример запроса для "Ковбоя Бибопа" с озвучкой KansaiStudio
Запрос: 
"print(pars.get_link("1", "shikimori", 1, "559"))"

Ответ: 
"('\\xff\\xfarn\\x1a\\xb1n\\xab\\xf1~\\x06\\xde\\x9e\\xda\\xe9o?\\xe1~\\xb7\\xa1s&\\xe7\\xa9\\xff\\xf7\\xefN\\xb9\\xdf\\xde\\xe9\\xb3Jx\\xae\\x7f}\\xdb\\xaf{\\xd7\\xcd\\xbb\\xf3\\x8et\\xa7\\xbe\\xff\\x9fy\\xec\\xdbMy\\x9f\\xbd\\xa9\\xea\\x8f*\\x9f\\x9d+\\xde\\xbb*\\xab\\xa9\\xfb\\xa7z5\\xdbM\\xb9\\xd3}<\\xd3\\xcf\\xf7\\xebL\\xdc\\xe2\\xec\\x9f\\x', 720)"

Похоже на то что Kodik убрал шифрование ссылок на потоковое видео, поэтому функции "_convert_char" и "_convert" не нужны. Без них:
Запрос: 

"print(pars.get_link("1", "shikimori", 1, "559"))"
Ответ:

"('cloud.kodik-storage.com/useruploads/37065397-cf0c-4ea9-9269-718278450c77/a3af2015a72c6b8da50e3efdd6a7c3b1:2025030808', 720)"