### PR TITLE
Исправления под новую шифровку Kodik и небольшие улучшения

### DIFF
--- a/src/anime_parsers_ru/errors.py
+++ b/src/anime_parsers_ru/errors.py
@@ -3,35 +3,42 @@ class TokenError(Exception):
     Ошибка для обозначения неверного токена.
     """
 
+
 class ServiceError(Exception):
     """
     Ошибка для обозначения ошибки на стороне сервера
     """
+
 
 class PostArgumentsError(Exception):
     """
     Ошибка для обозначения неверно переданных аргументов серверу
     """
 
+
 class NoResults(Exception):
     """
     Ошибка для обозначения отсутствия результатов
     """
+
 
 class UnexpectedBehavior(Exception):
     """
     Ошибка для обозначения неожиданного или необработанного поведения
     """
 
+
 class QualityNotFound(Exception):
     """
     Ошибка для обозначения не найденного запрашиваемого качества видео
     """
 
+
 class AgeRestricted(Exception):
     """
     Ошибка для обозначения что контент заблокирован из-за возрастного рейтинга
     """
+
 
 class TooManyRequests(Exception):
     """
@@ -39,13 +46,19 @@ class TooManyRequests(Exception):
     В основном для шикимори
     """
 
+
 class ContentBlocked(Exception):
     """
     Ошибка для обозначения заблокированного контента/плеера
     """
+
 
 class ServiceIsOverloaded(Exception):
     """
     Ошибка для обозначения http кода 520
     Используется в парсере shikimori
     """
+
+
+class DecryptionFailure(Exception):
+    """При попытке дешифровать ссылку от Kodik возникла ошибка"""

--- a/src/anime_parsers_ru/parser_kodik.py
+++ b/src/anime_parsers_ru/parser_kodik.py
@@ -530,8 +530,7 @@ class KodikParser:
             translations = [{"id": "0", "type": "Неизвестно", "name": "Неизвестно"}]
         return translations
 
-    def get_link(self, id: str, id_type: str, seria_num: int, 
-                 translation_id: str, crypted: bool = False) -> tuple[str, int]:
+    def get_link(self, id: str, id_type: str, seria_num: int, translation_id: str) -> tuple[str, int]:
         """
         ### Для использования требуется токен kodik
         Возвращает ссылку на видео файл.
@@ -614,15 +613,12 @@ class KodikParser:
         video_id = hash_container[hash_container.find(".id = '") + 7 :]
         video_id = video_id[: video_id.find("'")]
 
-        link_data, max_quality = self._get_link_with_data(
-            video_type, video_hash, video_id, urlParams, script_url, crypted
-        )
+        link_data, max_quality = self._get_link_with_data(video_type, video_hash, video_id, urlParams, script_url)
 
         download_url = str(link_data).replace("https:", "")[:-25]
         return download_url, max_quality
 
-    def _get_link_with_data(self, video_type: str, video_hash: str, video_id: str, 
-                            urlParams: dict, script_url: str, crypted: bool = False):
+    def _get_link_with_data(self, video_type: str, video_hash: str, video_id: str, urlParams: dict, script_url: str):
         params = {
             "hash": video_hash,
             "id": video_id,
@@ -642,16 +638,16 @@ class KodikParser:
         post_link = self._get_post_link(script_url)
         data = requests.post(f"https://kodik.info{post_link}", data=params, headers=headers).json()
         data_url = data["links"]["360"][0]["src"]
-        url = data_url if not crypted else self._convert(data_url)
+        url = data_url if "mp4:hls:manifest.m3u8" in data_url else self._convert(data_url)
         max_quality = max([int(x) for x in data["links"].keys()])
 
         return url, max_quality
 
-    def _convert_char(self, char: str):
+    def _convert_char(self, char: str, num):
         low = char.islower()
         alph = "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
         if char.upper() in alph:
-            ch = alph[(alph.index(char.upper()) + 13) % len(alph)]
+            ch = alph[(alph.index(char.upper()) + num) % len(alph)]
             if low:
                 return ch.lower()
             else:
@@ -661,11 +657,19 @@ class KodikParser:
 
     def _convert(self, string: str):
         # Декодирование строки со ссылкой
-        crypted_url = "".join(map(self._convert_char, list(string)))
-        try:
-            return b64decode(crypted_url.encode())
-        except:
-            return str(b64decode(crypted_url.encode() + b"=="))
+        
+        for rot in range(25):
+            crypted_url = "".join([self._convert_char(i, rot) for i in string])
+            padding = (4 - (len(crypted_url) % 4)) % 4
+            crypted_url += "=" * padding
+            try:
+                result = b64decode(crypted_url).decode("utf-8")
+                if "mp4:hls:manifest.m3u8"in result:
+                    return result
+            except UnicodeDecodeError:
+                continue
+        else:
+            raise errors.DecryptionFailure
 
     def _get_post_link(self, script_url: str):
         data = requests.get("https://kodik.info" + script_url).text


### PR DESCRIPTION
Привет ! 

Кодик вернул шифровку на ссылки потокового видео и чуть ее изменил. Конкретно ротацию с 13 символов на 18 если я не ошибаюсь. 

Я поменял `_convert_char`  чтобы решить проблему сейчас и в будущем. (не нужно будет менять ротации вручную) 
Убрал параметр crypto, расшифровка ссылки теперь применяется по необходимости. 
В **errors.py** добавил исключение `DecryptionFailure`.

Насчет того чего не уверен. Я реализовал проверку валидности ссылки, посредством поиска в ней подстроки `"mp4:hls:manifest.m3u8"`. Насколько я заметил, эта подстрока присутствует во всех ссылках потокового видео у кодика, поэтому вроде как можно так делать, но жду вашего мнения.