### PR TITLE
Исправление ошибки связанной с расшифровкой потоковый ссылки у некоторых аниме.

### DIFF
--- a/src/anime_parsers_ru/parser_kodik.py
+++ b/src/anime_parsers_ru/parser_kodik.py
@@ -616,7 +616,8 @@ class KodikParser:
 
         link_data, max_quality = self._get_link_with_data(video_type, video_hash, video_id, urlParams, script_url)
 
-        download_url = str(link_data).replace("https:", "")[:-25]
+        download_url = str(link_data).replace("https:", "")
+        download_url = download_url[: download_url.rfind("/") + 1]
         return download_url, max_quality
 
     def _get_link_with_data(self, video_type: str, video_hash: str, video_id: str, urlParams: dict, script_url: str):
@@ -639,7 +640,7 @@ class KodikParser:
         post_link = self._get_post_link(script_url)
         data = requests.post(f"https://kodik.info{post_link}", data=params, headers=headers).json()
         data_url = data["links"]["360"][0]["src"]
-        url = data_url if "mp4:hls:manifest.m3u8" in data_url else self._convert(data_url)
+        url = data_url if "mp4:hls:manifest" in data_url else self._convert(data_url)
         max_quality = max([int(x) for x in data["links"].keys()])
 
         return url, max_quality
@@ -665,7 +666,7 @@ class KodikParser:
             crypted_url += "=" * padding
             try:
                 result = b64decode(crypted_url).decode("utf-8")
-                if "mp4:hls:manifest.m3u8" in result:
+                if "mp4:hls:manifest" in result:
                     return result
             except UnicodeDecodeError:
                 pass
@@ -676,7 +677,7 @@ class KodikParser:
             crypted_url += "=" * padding
             try:
                 result = b64decode(crypted_url).decode("utf-8")
-                if "mp4:hls:manifest.m3u8" in result:
+                if "mp4:hls:manifest" in result:
                     self._crypt_step = rot
                     return result
             except UnicodeDecodeError:

--- a/src/anime_parsers_ru/parser_kodik_async.py
+++ b/src/anime_parsers_ru/parser_kodik_async.py
@@ -615,7 +615,8 @@ class KodikParserAsync:
 
         link_data, max_quality = await self._get_link_with_data(video_type, video_hash, video_id, urlParams, script_url)
 
-        download_url = str(link_data).replace("https:", "")[:-25]
+        download_url = str(link_data).replace("https:", "")
+        download_url = download_url[: download_url.rfind("/") + 1]
         return download_url, max_quality
     
     async def _get_link_with_data(self, video_type: str, video_hash: str, video_id: str, urlParams: dict, script_url: str):
@@ -641,7 +642,7 @@ class KodikParserAsync:
         data = await self.requests.post(f'https://kodik.info{post_link}', data=params, headers=headers)
         data = data.json()
         data_url = data["links"]["360"][0]["src"]
-        url = data_url if "mp4:hls:manifest.m3u8" in data_url else self._convert(data_url)
+        url = data_url if "mp4:hls:manifest" in data_url else self._convert(data_url)
         max_quality = max([int(x) for x in data["links"].keys()])
 
         return url, max_quality
@@ -667,7 +668,7 @@ class KodikParserAsync:
             crypted_url += "=" * padding
             try:
                 result = b64decode(crypted_url).decode("utf-8")
-                if "mp4:hls:manifest.m3u8" in result:
+                if "mp4:hls:manifest" in result:
                     return result
             except UnicodeDecodeError:
                 pass
@@ -678,7 +679,7 @@ class KodikParserAsync:
             crypted_url += "=" * padding
             try:
                 result = b64decode(crypted_url).decode("utf-8")
-                if "mp4:hls:manifest.m3u8" in result:
+                if "mp4:hls:manifest" in result:
                     self._crypt_step = rot
                     return result
             except UnicodeDecodeError:


### PR DESCRIPTION
Снова привет! Я обнаружил что есть аниме, у которых потоковые ссылки почему-то отличаются от обычных и их не поймать с помощью  `if "mp4:hls:manifest.m3u8" in data_url`.  К примеру "Тетрадь смерти" (id:"1535", id_type: "shikimori", seria_num: 1, translation_id: "793"). 

Вот какую потоковую ссылку мы получим:

https://cloud.kodik-cdn.com/animetvseries/397bb917e9fbf95753c48acab73afe0ad0a6a4e2/9f20ac3e703e4827a5f69ed3630c6ae7:2025052208/360.mp4:hls:manifest-v1-a2.m3u8

Очевидно что в данном случае `if "mp4:hls:manifest.m3u8" in data_url` не выполнится, цикл пройдет и выбросится `DecryptionFailure`, поэтому я поменял условие на `if "mp4:hls:manifest" in data_url`. 

Далее, такую ссылку не привести к нужному нам виду через:

`download_url = str(link_data).replace("https:", "")[:-25]`

 мы получим:

_//cloud.kodik-cdn.com/animetvseries/397bb917e9fbf95753c48acab73afe0ad0a6a4e2/9f20ac3e703e4827a5f69ed3630c6ae7:2025052208/360.mp_

Ссылка не обрезается до конца поэтому так:

`download_url = str(link_data).replace("https:", "")`
`download_url = download_url[: download_url.rfind("/") + 1]`

На выходе мы получаем:

_//cloud.kodik-cdn.com/animetvseries/397bb917e9fbf95753c48acab73afe0ad0a6a4e2/9f20ac3e703e4827a5f69ed3630c6ae7:2025052208/', 720_